### PR TITLE
MATLABファイルのinputノード追加

### DIFF
--- a/frontend/src/api/files/Files.ts
+++ b/frontend/src/api/files/Files.ts
@@ -7,6 +7,7 @@ export const FILE_TREE_TYPE_SET = {
   CSV: 'csv',
   HDF5: 'hdf5',
   FLUO: 'fluo',
+  MATLAB: 'matlab',
   BEHAVIOR: 'behavior',
   ALL: 'all',
 } as const

--- a/frontend/src/components/FlowChart/FlowChartNode/FileSelect.tsx
+++ b/frontend/src/components/FlowChart/FlowChartNode/FileSelect.tsx
@@ -145,6 +145,8 @@ function getFileInputAccept(fileType: FILE_TREE_TYPE | undefined) {
       return '.csv'
     case FILE_TREE_TYPE_SET.HDF5:
       return '.hdf5,.nwb'
+    case FILE_TREE_TYPE_SET.MATLAB:
+      return '.mat'
     default:
       return undefined
   }

--- a/frontend/src/components/FlowChart/FlowChartNode/MatlabFileNode.tsx
+++ b/frontend/src/components/FlowChart/FlowChartNode/MatlabFileNode.tsx
@@ -1,0 +1,84 @@
+import React, { CSSProperties } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { Handle, NodeProps, Position } from 'react-flow-renderer'
+import {
+  selectInputNodeDefined,
+  selectMatlabInputNodeSelectedFilePath,
+} from 'store/slice/InputNode/InputNodeSelectors'
+import { setInputNodeFilePath } from 'store/slice/InputNode/InputNodeActions'
+import { alpha, useTheme } from '@mui/material/styles'
+import { deleteFlowElementsById } from 'store/slice/FlowElement/FlowElementSlice'
+import { FileSelect } from './FileSelect'
+import { toHandleId } from './FlowChartUtils'
+import { FILE_TYPE_SET } from 'store/slice/InputNode/InputNodeType'
+import { arrayEqualityFn } from 'utils/EqualityUtils'
+
+const sourceHandleStyle: CSSProperties = {
+  width: 8,
+  height: 15,
+  top: 15,
+  border: '1px solid',
+  borderColor: '#555',
+  borderRadius: 0,
+}
+export const MatlabFileNode = React.memo<NodeProps>((element) => {
+  const defined = useSelector(selectInputNodeDefined(element.id))
+  if (defined) {
+    return <MatlabFileNodeImpl {...element} />
+  } else {
+    return null
+  }
+})
+
+const MatlabFileNodeImpl = React.memo<NodeProps>(({ id: nodeId, selected }) => {
+  const dispatch = useDispatch()
+  const filePath = useSelector(
+    selectMatlabInputNodeSelectedFilePath(nodeId),
+    (a, b) => (a != null && b != null ? arrayEqualityFn(a, b) : a === b),
+  )
+  const onChangeFilePath = (path: string[]) => {
+    dispatch(setInputNodeFilePath({ nodeId, filePath: path }))
+  }
+  const theme = useTheme()
+
+  const onClickDeleteIcon = () => {
+    dispatch(deleteFlowElementsById(nodeId))
+  }
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        width: '250px',
+        background: selected
+          ? alpha(theme.palette.primary.light, 0.1)
+          : undefined,
+      }}
+    >
+      <button
+        className="flowbutton"
+        onClick={onClickDeleteIcon}
+        style={{ color: 'black', position: 'absolute', top: -10, right: 10 }}
+      >
+        ×
+      </button>
+      <FileSelect
+        nodeId={nodeId}
+        multiSelect
+        onChangeFilePath={(path) => {
+          if (Array.isArray(path)) {
+            onChangeFilePath(path)
+          }
+        }}
+        fileType={FILE_TYPE_SET.MATLAB}
+        filePath={filePath ?? []}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id={toHandleId(nodeId, 'matlab', 'MatlabData')}
+        style={sourceHandleStyle}
+      />
+    </div>
+  )
+})

--- a/frontend/src/components/FlowChart/FlowChartNode/ReactFlowNodeTypesConst.ts
+++ b/frontend/src/components/FlowChart/FlowChartNode/ReactFlowNodeTypesConst.ts
@@ -4,6 +4,7 @@ import { CsvFileNode } from 'components/FlowChart/FlowChartNode/CsvFileNode'
 import { HDF5FileNode } from 'components/FlowChart/FlowChartNode/HDF5FileNode'
 import { FluoFileNode } from 'components/FlowChart/FlowChartNode/FluoFileNode'
 import { BehaviorFileNode } from 'components/FlowChart/FlowChartNode/BehaviorFileNode'
+import { MatlabFileNode } from 'components/FlowChart/FlowChartNode/MatlabFileNode'
 
 import { CustomEdge } from 'components/FlowChart/CustomEdge'
 
@@ -14,6 +15,7 @@ export const reactFlowNodeTypes = {
   AlgorithmNode,
   FluoFileNode,
   BehaviorFileNode,
+  MatlabFileNode,
 } as const
 
 export const reactFlowEdgeTypes = {

--- a/frontend/src/components/FlowChart/TreeView.tsx
+++ b/frontend/src/components/FlowChart/TreeView.tsx
@@ -107,6 +107,11 @@ export const AlgorithmTreeView = React.memo(() => {
           nodeName={'behaviorData'}
           fileType={FILE_TYPE_SET.BEHAVIOR}
         />
+        <InputNodeComponent
+          fileName={'matlab'}
+          nodeName={'matalabData'}
+          fileType={FILE_TYPE_SET.MATLAB}
+        />
       </TreeItem>
       <TreeItem nodeId="Algorithm" label="Algorithm">
         {Object.entries(algoList).map(([name, node], i) => (
@@ -156,6 +161,10 @@ const InputNodeComponent = React.memo<{
         case FILE_TYPE_SET.BEHAVIOR:
           reactFlowNodeType = REACT_FLOW_NODE_TYPE_KEY.BehaviorFileNode
           fileType = FILE_TYPE_SET.BEHAVIOR
+          break
+        case FILE_TYPE_SET.MATLAB:
+          reactFlowNodeType = REACT_FLOW_NODE_TYPE_KEY.MatlabFileNode
+          fileType = FILE_TYPE_SET.MATLAB
           break
       }
       const newNode = {

--- a/frontend/src/components/Visualize/FilePathSelect.tsx
+++ b/frontend/src/components/Visualize/FilePathSelect.tsx
@@ -27,7 +27,12 @@ export const FilePathSelect: React.FC<{
   dataType?: DATA_TYPE
   selectedNodeId: string | null
   selectedFilePath: string | null
-  onSelect: (nodeId: string, filePath: string, dataType: DATA_TYPE, outputKey?: string) => void
+  onSelect: (
+    nodeId: string,
+    filePath: string,
+    dataType: DATA_TYPE,
+    outputKey?: string,
+  ) => void
   label?: string
 }> = ({ dataType, selectedNodeId, selectedFilePath, onSelect, label }) => {
   const inputNodeFilePathInfoList = useSelector(
@@ -89,7 +94,7 @@ export const FilePathSelect: React.FC<{
     nodeId: string,
     filePath: string,
     dataType: DATA_TYPE,
-    outputKey?: string
+    outputKey?: string,
   ) => {
     onSelect(nodeId, filePath, dataType, outputKey)
     handleClose()
@@ -137,7 +142,7 @@ export const FilePathSelect: React.FC<{
               pathInfo.nodeId,
               outputPath.filePath,
               outputPath.type,
-              outputPath.outputKey
+              outputPath.outputKey,
             )
           }
           key={`${pathInfo.nodeId}/${outputPath.filePath}`}
@@ -178,5 +183,7 @@ function toDataTypeFromFileType(fileType: FILE_TYPE) {
       return DATA_TYPE_SET.FLUO
     case FILE_TYPE_SET.BEHAVIOR:
       return DATA_TYPE_SET.BEHAVIOR
+    case FILE_TYPE_SET.MATLAB:
+      return DATA_TYPE_SET.MATLAB
   }
 }

--- a/frontend/src/const/flowchart.ts
+++ b/frontend/src/const/flowchart.ts
@@ -20,6 +20,7 @@ export const REACT_FLOW_NODE_TYPE_KEY = {
   FluoFileNode: 'FluoFileNode',
   AlgorithmNode: 'AlgorithmNode',
   BehaviorFileNode: 'BehaviorFileNode',
+  MatlabFileNode: 'MatlabFileNode',
 } as const
 
 export type REACT_FLOW_NODE_TYPE =

--- a/frontend/src/store/slice/DisplayData/DisplayDataType.ts
+++ b/frontend/src/store/slice/DisplayData/DisplayDataType.ts
@@ -53,6 +53,7 @@ export const DATA_TYPE_SET = {
   HTML: 'html',
   FLUO: 'fluo',
   BEHAVIOR: 'behavior',
+  MATLAB: 'matlab',
 } as const
 
 export type DATA_TYPE = typeof DATA_TYPE_SET[keyof typeof DATA_TYPE_SET]

--- a/frontend/src/store/slice/InputNode/InputNodeSelectors.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSelectors.ts
@@ -3,6 +3,7 @@ import {
   isHDF5InputNode,
   isCsvInputNode,
   isImageInputNode,
+  isMatlabInputNode,
 } from './InputNodeUtils'
 
 export const selectInputNode = (state: RootState) => state.inputNode
@@ -44,6 +45,16 @@ export const selectHDF5InputNodeSelectedFilePath =
   (nodeId: string) => (state: RootState) => {
     const node = selectInputNodeById(nodeId)(state)
     if (isHDF5InputNode(node)) {
+      return node.selectedFilePath
+    } else {
+      throw new Error('invaid input node type')
+    }
+  }
+
+export const selectMatlabInputNodeSelectedFilePath =
+  (nodeId: string) => (state: RootState) => {
+    const node = selectInputNodeById(nodeId)(state)
+    if (isMatlabInputNode(node)) {
       return node.selectedFilePath
     } else {
       throw new Error('invaid input node type')

--- a/frontend/src/store/slice/InputNode/InputNodeSlice.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeSlice.ts
@@ -96,6 +96,12 @@ export const inputNodeSlice = createSlice({
                 param: {},
               }
               break
+            case FILE_TYPE_SET.MATLAB:
+              state[node.id] = {
+                fileType,
+                param: {},
+              }
+              break
             case FILE_TYPE_SET.FLUO:
               state[node.id] = {
                 fileType: FILE_TYPE_SET.CSV,

--- a/frontend/src/store/slice/InputNode/InputNodeType.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeType.ts
@@ -6,6 +6,7 @@ export const FILE_TYPE_SET = {
   HDF5: 'hdf5',
   FLUO: 'fluo',
   BEHAVIOR: 'behavior',
+  MATLAB: 'matlab',
 } as const
 
 export type FILE_TYPE = typeof FILE_TYPE_SET[keyof typeof FILE_TYPE_SET]
@@ -14,7 +15,11 @@ export type InputNode = {
   [nodeId: string]: InputNodeType
 }
 
-export type InputNodeType = CsvInputNode | ImageInputNode | HDF5InputNode
+export type InputNodeType =
+  | CsvInputNode
+  | ImageInputNode
+  | HDF5InputNode
+  | MatlabInputNode
 
 interface InputNodeBaseType<
   T extends FILE_TYPE,
@@ -43,4 +48,8 @@ export interface ImageInputNode extends InputNodeBaseType<'image', {}> {
 export interface HDF5InputNode extends InputNodeBaseType<'hdf5', {}> {
   selectedFilePath?: string
   hdf5Path?: string
+}
+
+export interface MatlabInputNode extends InputNodeBaseType<'matlab', {}> {
+  selectedFilePath?: string[]
 }

--- a/frontend/src/store/slice/InputNode/InputNodeUtils.ts
+++ b/frontend/src/store/slice/InputNode/InputNodeUtils.ts
@@ -4,6 +4,7 @@ import {
   HDF5InputNode,
   InputNodeType,
   FILE_TYPE_SET,
+  MatlabInputNode,
 } from './InputNodeType'
 
 export function isImageInputNode(
@@ -22,4 +23,10 @@ export function isHDF5InputNode(
   inputNode: InputNodeType,
 ): inputNode is HDF5InputNode {
   return inputNode.fileType === FILE_TYPE_SET.HDF5
+}
+
+export function isMatlabInputNode(
+  inputNode: InputNodeType,
+): inputNode is MatlabInputNode {
+  return inputNode.fileType === FILE_TYPE_SET.MATLAB
 }

--- a/frontend/src/store/slice/VisualizeItem/VisualizeItemSlice.ts
+++ b/frontend/src/store/slice/VisualizeItem/VisualizeItemSlice.ts
@@ -22,6 +22,7 @@ import {
   FluoItem,
   BehaviorItem,
   VISUALIZE_ITEM_SLICE_NAME,
+  MatlabItem,
 } from './VisualizeItemType'
 import {
   isDisplayDataItem,
@@ -133,6 +134,10 @@ const behaviorItemInitialValue: BehaviorItem = {
   ...displayDataCommonInitialValue,
   dataType: DATA_TYPE_SET.BEHAVIOR,
 }
+const matlabItemInitialValue: MatlabItem = {
+  ...displayDataCommonInitialValue,
+  dataType: DATA_TYPE_SET.MATLAB,
+}
 
 function getDisplayDataItemInitialValue(dataType: DATA_TYPE) {
   switch (dataType) {
@@ -158,6 +163,8 @@ function getDisplayDataItemInitialValue(dataType: DATA_TYPE) {
       return fluoItemInitialValue
     case DATA_TYPE_SET.BEHAVIOR:
       return behaviorItemInitialValue
+    case DATA_TYPE_SET.MATLAB:
+      return matlabItemInitialValue
   }
 }
 

--- a/frontend/src/store/slice/VisualizeItem/VisualizeItemType.ts
+++ b/frontend/src/store/slice/VisualizeItem/VisualizeItemType.ts
@@ -44,6 +44,7 @@ export type DisplayDataItem =
   | HTMLItem
   | FluoItem
   | BehaviorItem
+  | MatlabItem
 
 export interface DisplayDataItemBaseType extends ItemBaseType<'displayData'> {
   filePath: string | null
@@ -131,4 +132,8 @@ export interface FluoItem extends DisplayDataItemBaseType {
 
 export interface BehaviorItem extends DisplayDataItemBaseType {
   dataType: typeof DATA_TYPE_SET.BEHAVIOR
+}
+
+export interface MatlabItem extends DisplayDataItemBaseType {
+  dataType: typeof DATA_TYPE_SET.MATLAB
 }

--- a/optinist/api/dataclass/dataclass.py
+++ b/optinist/api/dataclass/dataclass.py
@@ -7,6 +7,7 @@ from optinist.api.dataclass.html import HTMLData
 from optinist.api.dataclass.image import ImageData, RoiData
 from optinist.api.dataclass.iscell import IscellData
 from optinist.api.dataclass.lccd import LccdData
+from optinist.api.dataclass.matlab import MatlabData
 from optinist.api.dataclass.nwb import NWBFile
 from optinist.api.dataclass.scatter import ScatterData
 from optinist.api.dataclass.suite2p import Suite2pData
@@ -23,6 +24,7 @@ __all__ = [
     "RoiData",
     "IscellData",
     "LccdData",
+    "MatlabData",
     "NWBFile",
     "ScatterData",
     "Suite2pData",

--- a/optinist/api/dataclass/matlab.py
+++ b/optinist/api/dataclass/matlab.py
@@ -1,4 +1,3 @@
-import numpy as np
 import scipy.io as sio
 
 from optinist.api.dataclass.base import BaseData
@@ -12,5 +11,3 @@ class MatlabData(BaseData):
 
         if isinstance(data, str):
             self.data = sio.loadmat(data)
-        else:
-            self.data = self.data = np.array(data)

--- a/optinist/api/dataclass/matlab.py
+++ b/optinist/api/dataclass/matlab.py
@@ -1,0 +1,16 @@
+import numpy as np
+import scipy.io as sio
+
+from optinist.api.dataclass.base import BaseData
+from optinist.api.dir_path import DIRPATH
+
+
+class MatlabData(BaseData):
+    def __init__(self, data, output_dir=DIRPATH.OUTPUT_DIR, file_name="matlab"):
+        super().__init__(file_name)
+        self.json_path = None
+
+        if isinstance(data, str):
+            self.data = sio.loadmat(data)
+        else:
+            self.data = self.data = np.array(data)

--- a/optinist/routers/const.py
+++ b/optinist/routers/const.py
@@ -1,5 +1,6 @@
 ACCEPT_TIFF_EXT = [".tif", ".tiff", ".TIF", ".TIFF"]
 ACCEPT_CSV_EXT = [".csv"]
 ACCEPT_HDF5_EXT = [".hdf5", ".nwb", ".HDF5", ".NWB"]
+ACCEPT_MATLAB_EXT = [".mat"]
 
 NOT_DISPLAY_ARGS_LIST = ["params", "output_dir", "nwbfile"]

--- a/optinist/routers/files.py
+++ b/optinist/routers/files.py
@@ -7,7 +7,12 @@ from fastapi import APIRouter, File, UploadFile
 
 from optinist.api.dir_path import DIRPATH
 from optinist.api.utils.filepath_creater import create_directory, join_filepath
-from optinist.routers.const import ACCEPT_CSV_EXT, ACCEPT_HDF5_EXT, ACCEPT_TIFF_EXT
+from optinist.routers.const import (
+    ACCEPT_CSV_EXT,
+    ACCEPT_HDF5_EXT,
+    ACCEPT_MATLAB_EXT,
+    ACCEPT_TIFF_EXT,
+)
 from optinist.routers.model import FILETYPE, FilePath, TreeNode
 
 router = APIRouter()
@@ -74,6 +79,8 @@ async def get_files(file_type: str = None):
         return DirTreeGetter.get_tree(ACCEPT_CSV_EXT)
     elif file_type == FILETYPE.HDF5:
         return DirTreeGetter.get_tree(ACCEPT_HDF5_EXT)
+    elif file_type == FILETYPE.MATLAB:
+        return DirTreeGetter.get_tree(ACCEPT_MATLAB_EXT)
 
 
 @router.post("/files/upload/{filename}", response_model=FilePath, tags=["files"])

--- a/optinist/routers/model.py
+++ b/optinist/routers/model.py
@@ -39,6 +39,7 @@ class FILETYPE:
     IMAGE: str = "image"
     CSV: str = "csv"
     HDF5: str = "hdf5"
+    MATLAB: str = "matlab"
     BEHAVIOR: str = "behavior"
 
 


### PR DESCRIPTION
- `.mat`形式に対応したinputノードを追加
  - Imageと同様にmulti selectで実装
  - uploadまで可能

  ![Screenshot 2023-05-30 at 14 48 51](https://github.com/arayabrain/on-premises-optinist/assets/42664619/6ca6170a-f23c-481d-8f19-ada2a2cd841b)
  
  ![Screenshot 2023-05-30 at 14 48 59](https://github.com/arayabrain/on-premises-optinist/assets/42664619/54ff1c05-6309-4cbd-a886-6aa7880783a4)

- 現状はBackendでは`scipy.io.loadmat`でloadしたdict型のデータで保持するのみ

## 今後の課題

- matlabファイル自体が任意のkey, valueを持つことができるため、後続の処理にどのように渡すか
  - キー名、データ型を設定するUIをinputノードに組み込む
  - 特定のパターンに絞って専用のノードを開発する

